### PR TITLE
docs: add CLAUDE.md codebase documentation

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,24 +1,25 @@
 # python-template
 
-A Python project template demonstrating modern best practices: ruff linting, mypy type checking, bandit security scanning, and pytest with coverage.
+A Python project template demonstrating modern best practices: ruff linting,
+mypy type checking, bandit security scanning, and pytest with coverage.
 
 ## Key Commands
 
 ```bash
-make install      # install runtime dependencies
-make install-dev  # install all dev dependencies
-make lint         # ruff check + mypy
+make install      # install the package in editable mode
+make install-dev  # install the package in editable mode with dev dependencies
+make lint         # ruff check
 make format       # ruff format (auto-fix)
-make test         # pytest with coverage
-make security     # bandit + safety
-make all          # lint + type-check + test + security
+make test         # pytest
+make security     # bandit + pip-audit
+make all          # format + lint + type-check + security + test-cov
 ```
 
 ## Structure
 
-```
+```text
 src/hello_world/    # main package
-  main.py           # greet() and batch_greet() entry points
+  main.py           # greet() and greet_many() entry points
   validators.py     # validate_name() input guard
   exceptions.py     # GreetingError, ValidationError, BatchGreetingError
 tests/              # pytest suite (mirrors src/)
@@ -29,11 +30,11 @@ tests/              # pytest suite (mirrors src/)
 - **Linting**: `ruff check --fix` (replaces flake8/isort/pylint)
 - **Formatting**: `ruff format`
 - **Types**: `mypy src/` (strict mode via pyproject.toml)
-- **Security**: `bandit -r src/` + `safety check`
+- **Security**: `bandit -r src/` + `pip-audit`
 - **Tests**: `pytest --cov=src/hello_world` — 100% coverage expected
 - **Pre-commit**: hooks run ruff, mypy, bandit, trailing-whitespace on every commit
 
 ## CI Workflows
 
-- `ci.yml` — Code Quality (ruff + mypy)
+- `ci.yml` — Code Quality (ruff + mypy + bandit + pip-audit + docstring check)
 - `tests.yml` — Tests across Python 3.11/3.12/3.13 with Codecov upload

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,39 @@
+# python-template
+
+A Python project template demonstrating modern best practices: ruff linting, mypy type checking, bandit security scanning, and pytest with coverage.
+
+## Key Commands
+
+```bash
+make install      # install runtime dependencies
+make install-dev  # install all dev dependencies
+make lint         # ruff check + mypy
+make format       # ruff format (auto-fix)
+make test         # pytest with coverage
+make security     # bandit + safety
+make all          # lint + type-check + test + security
+```
+
+## Structure
+
+```
+src/hello_world/    # main package
+  main.py           # greet() and batch_greet() entry points
+  validators.py     # validate_name() input guard
+  exceptions.py     # GreetingError, ValidationError, BatchGreetingError
+tests/              # pytest suite (mirrors src/)
+```
+
+## Development Conventions
+
+- **Linting**: `ruff check --fix` (replaces flake8/isort/pylint)
+- **Formatting**: `ruff format`
+- **Types**: `mypy src/` (strict mode via pyproject.toml)
+- **Security**: `bandit -r src/` + `safety check`
+- **Tests**: `pytest --cov=src/hello_world` — 100% coverage expected
+- **Pre-commit**: hooks run ruff, mypy, bandit, trailing-whitespace on every commit
+
+## CI Workflows
+
+- `ci.yml` — Code Quality (ruff + mypy)
+- `tests.yml` — Tests across Python 3.11/3.12/3.13 with Codecov upload


### PR DESCRIPTION
Closes #40

## Summary

- Adds `CLAUDE.md` to document this repo for AI agents and developers
- Corrects all command comments and tool names to match the actual `Makefile` and source

## Changes

- `CLAUDE.md` (new) — key `make` commands, package structure, dev conventions, CI workflows
- Commands corrected: `make lint` (ruff only), `make test` (pytest only), `make security` (bandit + pip-audit), `make all` (format + lint + type-check + security + test-cov)
- Structure corrected: `main.py` entry points are `greet()` and `greet_many()` (not `batch_greet()`)
- Security convention: `pip-audit` (not `safety check`)
- CI description: includes full check list (ruff + mypy + bandit + pip-audit + docstring check)

## Test Plan

- [x] All existing pytest (3.11/3.12/3.13) pass — no code changes
- [x] Lint & Format Check, Type Check, Security Scan, Documentation Check all pass
- [x] CodeQL clean — 0 open alerts
- [x] All 12 review threads from gemini-code-assist and copilot-pull-request-reviewer resolved

---

Generated by Issue Solver — prompt source: <https://github.com/JacobPEvans/claude-code-routines/blob/main/routines/issue-solver.prompt.md>