### PR TITLE
fix(ci): ignore disputed joblib + nltk advisories in pip-audit

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -83,8 +83,14 @@ jobs:
         bandit -r src/ -c pyproject.toml
 
     - name: Run pip-audit for dependency vulnerabilities
+      # Disputed/contextual transitive vulnerabilities with no upstream fix.
+      # Review quarterly and remove once upstream patches land.
+      #   PYSEC-2024-277 — joblib 1.5.3 NumpyArrayWrapper deserialization.
+      #     Disputed by supplier (only used during caching of trusted content).
+      #   PYSEC-2026-97 — nltk 3.9.4 filestring() arbitrary file read.
+      #     Requires user-controlled path input; not exposed by template code.
       run: |
-        pip-audit
+        pip-audit --ignore-vuln PYSEC-2024-277 --ignore-vuln PYSEC-2026-97
 
   docs:
     name: Documentation Check


### PR DESCRIPTION
## Summary

Two transitive Python deps trigger pip-audit failures with no upstream fix yet:

- **PYSEC-2024-277** (joblib 1.5.3) — NumpyArrayWrapper deserialization. The vendor disputes this because NumpyArrayWrapper is only used while caching trusted content.
- **PYSEC-2026-97** (nltk 3.9.4) — `filestring()` arbitrary file read. Requires user-controlled path input; not exposed by template code.

These block #52 (gh-aw SHA refresh) and any future Renovate lock PR. Since this is a template, forks should review quarterly and tighten as their actual usage exposes (or doesn't expose) these surfaces.

## Changes

- Add `--ignore-vuln PYSEC-2024-277 --ignore-vuln PYSEC-2026-97` to the existing `pip-audit` invocation
- Document each ID with rationale

## Test plan

- [ ] Security Scan job goes green on this PR
- [ ] After merge, retrigger #52 — should clear the security gate

## Cleanup

Drop each `--ignore-vuln` flag once upstream ships a fix. Review quarterly.

Related: #52