### PR TITLE
chore(template): fix placeholders, downgrade python-version, drop redundant safety

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,10 +17,10 @@ jobs:
     - name: Checkout code
       uses: actions/checkout@v6
 
-    - name: Set up Python 3.12
+    - name: Set up Python
       uses: actions/setup-python@v6
       with:
-        python-version: "3.14"
+        python-version: "3.13"
         cache: 'pip'
 
     - name: Install dependencies
@@ -44,10 +44,10 @@ jobs:
     - name: Checkout code
       uses: actions/checkout@v6
 
-    - name: Set up Python 3.12
+    - name: Set up Python
       uses: actions/setup-python@v6
       with:
-        python-version: "3.14"
+        python-version: "3.13"
         cache: 'pip'
 
     - name: Install dependencies
@@ -67,10 +67,10 @@ jobs:
     - name: Checkout code
       uses: actions/checkout@v6
 
-    - name: Set up Python 3.12
+    - name: Set up Python
       uses: actions/setup-python@v6
       with:
-        python-version: "3.14"
+        python-version: "3.13"
         cache: 'pip'
 
     - name: Install dependencies
@@ -94,10 +94,10 @@ jobs:
     - name: Checkout code
       uses: actions/checkout@v6
 
-    - name: Set up Python 3.12
+    - name: Set up Python
       uses: actions/setup-python@v6
       with:
-        python-version: "3.14"
+        python-version: "3.13"
         cache: 'pip'
 
     - name: Install dependencies

--- a/TEMPLATE.md
+++ b/TEMPLATE.md
@@ -19,8 +19,11 @@ Replace every `REPLACE_ME` token:
 git mv src/hello_world src/<your_package_name>
 ```
 
-Update any imports in `tests/` and elsewhere from `hello_world` to your
-package name.
+- Update any imports in `tests/` and elsewhere from `hello_world` to your
+  package name.
+- Update package-level metadata in `src/<your_package_name>/__init__.py`:
+  `__author__`, `__email__`, and `__version__` are currently hardcoded
+  with the template author's information and must be replaced.
 
 ## 3. Update README
 

--- a/TEMPLATE.md
+++ b/TEMPLATE.md
@@ -1,0 +1,56 @@
+# Template Instantiation Checklist
+
+This repo is a **fork-and-edit** Python project template. After forking, walk
+through each item below before opening your first real PR.
+
+## 1. Project identity (`pyproject.toml`)
+
+Replace every `REPLACE_ME` token:
+
+- `name = "REPLACE_ME-project-name"` → kebab-case PyPI distribution name
+- `authors = [{name = "REPLACE_ME Author", email = "replace-me@example.com"}]`
+- `description = "REPLACE_ME — short project description"`
+- `[tool.ruff.lint.isort] known-first-party = ["hello_world"]` →
+  match your actual package directory under `src/`
+
+## 2. Rename the package
+
+```bash
+git mv src/hello_world src/<your_package_name>
+```
+
+Update any imports in `tests/` and elsewhere from `hello_world` to your
+package name.
+
+## 3. Update README
+
+- Replace `python-template` references with your project name
+- Replace the example `hello_world` import/run snippets
+- Update the badge URLs (replace `JacobPEvans/python-template` with
+  `<your-org>/<your-repo>`)
+- Fix the Codecov token in the coverage badge (or remove it until you wire
+  up Codecov for the new repo)
+
+## 4. CI workflows (`.github/workflows/`)
+
+- `ci.yml` and `tests.yml` reference `JacobPEvans/python-template` in the
+  Codecov `slug:` — replace with `<your-org>/<your-repo>`
+- Confirm the Python `matrix` in `tests.yml` matches the versions you want
+  to support; the single-version jobs in `ci.yml` use the latest released
+  stable (`3.13`) — bump when you upgrade
+
+## 5. Strip template scaffolding
+
+Once everything is renamed and CI is green on your fork, delete this file:
+
+```bash
+git rm TEMPLATE.md
+git commit -m "chore: remove template instantiation checklist"
+```
+
+## Why fork-and-edit instead of Cookiecutter?
+
+The template doubles as a working repo for its own CI (linting, type checks,
+security scans, coverage gating). Cookiecutter-style placeholders would
+break that — the repo itself wouldn't be installable or testable. Fork
+copies the working state; you edit it in place.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -2,14 +2,16 @@
 requires = ["setuptools>=61.0"]
 build-backend = "setuptools.build_meta"
 
+# TEMPLATE: After forking, replace the placeholders below.
+# See TEMPLATE.md for the full instantiation checklist.
 [project]
-name = "hello-world"
+name = "REPLACE_ME-project-name"
 version = "0.1.0"
 license = {text = "Apache-2.0"}
 authors = [
-    {name = "Your Name", email = "your.email@example.com"},
+    {name = "REPLACE_ME Author", email = "replace-me@example.com"},
 ]
-description = "A simple Python project template"
+description = "REPLACE_ME — short project description"
 readme = "README.md"
 requires-python = ">=3.11"
 classifiers = [
@@ -202,6 +204,7 @@ convention = "google"
 max-complexity = 10
 
 [tool.ruff.lint.isort]
+# TEMPLATE: replace "hello_world" with the actual package name (matches src/<package>/).
 known-first-party = ["hello_world"]
 force-single-line = false
 lines-after-imports = 2

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -26,7 +26,6 @@ dev = [
     "mypy>=1.16.1",
     # Security
     "bandit[toml]>=1.8.0",
-    "safety>=3.0.0",
     # Testing
     "pytest>=8.4.1",
     "pytest-cov>=6.2.0",

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -10,7 +10,6 @@ mypy>=1.16.1
 
 # Security
 bandit[toml]>=1.8.0
-safety>=3.0.0
 pip-audit>=2.7.0
 
 # Testing


### PR DESCRIPTION
## Summary

Three independent template-hygiene fixes surfaced by the 2026-05-22 workspace sweep.

### 1. `python-version` desync in `ci.yml`

The `lint`, `type-check`, `security`, and `docs` jobs were pinned to Python `3.14` while their step names still said "Set up Python 3.12" — a stale label from a prior bump that never propagated to the version field. The test matrix (`tests.yml`) tops out at `3.13`, so the single-version jobs were running on a Python release ahead of what the tests cover.

Pin to `3.13` (latest stable, top of the test matrix) and drop the version number from the step name so future bumps don't desync the label again.

### 2. Redundant security tooling

Both `safety` and `pip-audit` were installed via `[project.optional-dependencies] dev`, but the CI workflow only runs `pip-audit`. `safety` is the legacy duplicate from Pyup; `pip-audit` is the PyPA-maintained advisory scanner backed by the same osv.dev database.

Worse: `safety` carries its own transitive vulns (`joblib`, `nltk`) that have been blocking CI on every PR (#56, #57). Dropping `safety` eliminates the false-positive chain entirely.

### 3. Placeholder identity in `pyproject.toml`

`name = "hello-world"`, `authors = [{name = "Your Name", email = "your.email@example.com"}]`, and the ruff `known-first-party = ["hello_world"]` were committed defaults that looked indistinguishable from real values. Forks could ship without realizing they needed to change them.

Switch to explicit `REPLACE_ME-project-name` / `REPLACE_ME Author` tokens, add a `TEMPLATE: ...` header comment in `pyproject.toml`, and add `TEMPLATE.md` with the full fork-and-edit checklist (project rename, package rename, README badges, CI slug updates, removal of the checklist itself).

## Closes / refs

- Refs #56 — commit 2 (`safety` drop) is the issue's suggested fix #1 and supersedes #57's "ignore disputed advisories" workaround.

## Test plan

- [x] `actionlint .github/workflows/*.yml` — clean
- [x] `python3 -c "import tomllib; tomllib.load(open('pyproject.toml','rb'))"` — parses
- [x] Pre-commit hooks pass on all three commits (signed, no `--no-verify`)
- [x] CI Security Scan job now succeeds without `--ignore-vuln` workarounds
- [x] All four `ci.yml` jobs run on Python `3.13`