### PR TITLE
chore(ci): add release-please caller [routine:distributor]

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -1,0 +1,8 @@
+name: release-please
+on:
+  push:
+    branches: [main]
+  workflow_dispatch:
+jobs:
+  run:
+    uses: JacobPEvans/ai-workflows/.github/workflows/release-please.yml@facc9a67ffdda22c75f5a94964fc5ab266cf3a60 # v0.16.0


### PR DESCRIPTION
The Distributor propagation PR.

## Workflow

`release-please.yml` — thin caller for [JacobPEvans/ai-workflows](https://github.com/JacobPEvans/ai-workflows) reusable workflow, pinned to `facc9a67ffdda22c75f5a94964fc5ab266cf3a60` (`v0.16.0`).

## Why this repo

Repo has `.github/workflows/*` paths → core tier. `release-please.yml` is absent (gap rank #1 of 1 core gaps for this repo).

## Required secrets

None — this workflow uses only public APIs and the runner-injected `GITHUB_TOKEN`.

## Checklist

- [ ] Workflow trigger appropriate for this repo's branch model
- [ ] Required secrets exist in repo settings (if applicable)
- [ ] CI passes on the PR branch before merge

## Provenance

- **Generated by:** [The Distributor](https://claude.ai/code) — cloud routine, daily at 14:00 UTC
- **Triggered:** Scheduled run on `2026-05-26`
- **Why this PR:** `JacobPEvans/python-template` matched the `core` tier predicate and is missing `release-please.yml` (Phase 4 gap rank #1).
- **State:** `distributor-state` gist — tracks closed-pair memory so previously-rejected combinations are not re-attempted.
- **Label:** `cloud-routine`
