### PR TITLE
fix(ci): retarget reusable-workflow uses: refs to current org homes

### DIFF
--- a/.github/workflows/gh-aw-pin-refresh.yml
+++ b/.github/workflows/gh-aw-pin-refresh.yml
@@ -25,7 +25,7 @@ jobs:
     permissions:
       contents: write
       pull-requests: write
-    uses: JacobPEvans/.github/.github/workflows/_gh-aw-pin-refresh.yml@main
+    uses: JacobPEvans-personal/.github/.github/workflows/_gh-aw-pin-refresh.yml@main
     with:
       operation: ${{ inputs.operation || 'compile' }}
     secrets:


### PR DESCRIPTION
## Root cause

GitHub Actions `uses:` does not follow repository transfer/rename redirects and cannot use variables. The `.github/workflows/gh-aw-pin-refresh.yml` workflow referenced `JacobPEvans/.github/` (the old personal account), which no longer routes correctly after the org migration.

## Fix

`JacobPEvans/.github/` → `JacobPEvans-personal/.github/` — the actual current home of the `.github` reusable workflows repo.

## Scope

1 file changed, 1 `uses:` line corrected. No lock files touched. Part of an org-wide sweep to fix hard-coded owner references broken by the JacobPEvans → dryvist / JacobPEvans-personal split.

🤖 Generated with [Claude Code](https://claude.com/claude-code)