### PR TITLE
docs(readme): make standalone — drop cross-repo narrative, link the hub

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,28 +4,42 @@
 [![Python Tests](https://github.com/JacobPEvans/python-template/actions/workflows/tests.yml/badge.svg)](https://github.com/JacobPEvans/python-template/actions/workflows/tests.yml)
 [![Code Coverage](https://codecov.io/github/JacobPEvans/python-template/graph/badge.svg?token=IFMKOLPQE9)](https://codecov.io/github/JacobPEvans/python-template)
 
-A minimal Python project template following modern best practices and industry standards.
+A minimal Python project template following modern best practices and industry
+standards. Use it as the starting point for a new Python package: clone it,
+rename the `hello_world` package, and replace the example code with your own.
 
-**Author:** JacobPEvans
-**Created:** July 12, 2025
 **License:** [Apache License 2.0](LICENSE)
 **Python Version:** 3.11+
 
-## 🚀 Quick Start
+## Features
+
+- Modern Python packaging with `pyproject.toml`
+- Automated testing with pytest and coverage
+- Dual GitHub Actions workflows (testing + code quality)
+- Pre-commit hooks for code quality enforcement
+- Type hints and mypy type checking
+- Code formatting and linting with Ruff
+- Pre-configured `.gitignore`
+- Enforced 100% code coverage
+
+## Installation
 
 ### Prerequisites
+
 - Python 3.11 or higher
 - Git
 
-### Installation
+### Steps
 
 1. **Clone this repository**
+
    ```bash
    git clone <repository-url>
    cd python-template
    ```
 
 2. **Create and activate a virtual environment**
+
    ```bash
    # Windows
    python -m venv .venv
@@ -35,9 +49,12 @@ A minimal Python project template following modern best practices and industry s
    python3 -m venv .venv
    source .venv/bin/activate
    ```
-   > **Note**: We use `.venv` as the directory name to match common conventions and ensure it's ignored by git.
+
+   > **Note**: We use `.venv` as the directory name to match common conventions
+   > and ensure it's ignored by git.
 
 3. **Install dependencies**
+
    ```bash
    # Development installation (includes dev dependencies)
    pip install -e ".[dev]"
@@ -45,81 +62,43 @@ A minimal Python project template following modern best practices and industry s
    # Or just production dependencies
    pip install -e .
    ```
-   > **Note**: The `-e` flag installs in "editable" mode, so changes to your code take effect immediately.
 
-4. **Set up pre-commit hooks (Required for contributing)**
+   > **Note**: The `-e` flag installs in "editable" mode, so changes to your code
+   > take effect immediately.
+
+4. **Set up pre-commit hooks (required for contributing)**
+
    ```bash
-   # Pre-commit is already installed with dev dependencies
-   # Install the git hook scripts
+   # Pre-commit is already installed with dev dependencies.
+   # Install the git hook scripts:
    pre-commit install
 
-   # (Optional) Run on all files to test setup
+   # (Optional) Run on all files to test the setup
    pre-commit run --all-files
    ```
-   > **Note**: Pre-commit hooks will run automatically on every commit and may auto-fix formatting issues.
 
-## 🧪 Running Tests
+   > **Note**: Pre-commit hooks run automatically on every commit and may
+   > auto-fix formatting issues.
+
+## Usage
+
+Run the hello world application:
 
 ```bash
-# Run all tests
-pytest
-
-# Run tests with coverage
-pytest --cov=src/hello_world --cov-report=html
-
-# Run tests with coverage (same as GitHub Actions/CodeCov) - REQUIRES 100% coverage
-pytest --cov --cov-branch --cov-report=xml --cov-fail-under=100
-
-# Run tests in verbose mode
-pytest -v
-
-# Run specific test file
-pytest tests/test_main.py -v
+python -m hello_world.main
 ```
 
-## 100% Code Coverage Required**
+Or import and use it in your code:
 
-This project enforces 100% code coverage. All pull requests must maintain 100% coverage or they will be automatically rejected by GitHub Actions.
+```python
+from hello_world import greet
 
-Use `pytest --cov --cov-branch --cov-report=xml --cov-fail-under=100` to ensure your changes meet this requirement before committing.
-
-## 🛠️ Development Tools
-
-### Code Quality & Pre-commit
-
-This project uses multiple workflows for maintaining code quality:
-
-#### GitHub Actions
-- **`tests.yml`**: Runs pytest with coverage across Python 3.11-3.13
-- **`ci.yml`**: Enforces code quality with auto-fixing and validation
-
-#### Pre-commit Hooks Setup
-Pre-commit hooks automatically run code formatting, linting, and type checking before each commit to ensure code quality.
-```bash
-# Pre-commit is already installed with dev dependencies
-# Install the git hook scripts
-pre-commit install
-
-# Test the setup
-pre-commit run --all-files
+print(greet("Python"))  # Output: Hello, Python!
 ```
-
-> **Note**: Once installed, pre-commit will automatically run on every `git commit`. If any checks fail, the commit will be blocked until issues are fixed. Code formatting tools like Black and isort will auto-fix many issues.
-
-## Features
-
-- ✅ Modern Python packaging with `pyproject.toml`
-- ✅ Automated testing with pytest and coverage
-- ✅ Dual GitHub Actions workflows (testing + code quality)
-- ✅ Pre-commit hooks for code quality enforcement
-- ✅ Type hints and mypy type checking
-- ✅ Code formatting with Black and isort
-- ✅ Linting with flake8
-- ✅ Pre-configured `.gitignore`
 
 ## Project Structure
 
-```
+```text
 python-template/
 ├── .github/
 │   └── workflows/
@@ -136,45 +115,8 @@ python-template/
 ├── .pre-commit-config.yaml    # Pre-commit hooks configuration
 ├── README.md                  # Project documentation
 ├── pyproject.toml             # Modern Python packaging & tool config
-├── pytest.ini                # Pytest configuration
+├── pytest.ini                 # Pytest configuration
 └── requirements-dev.txt       # Development dependencies
-```
-
-## Quick Setup (Alternative)
-
-If you prefer the minimal approach:
-
-1. Clone the repository:
-   ```bash
-   git clone <repository-url>
-   cd python-template
-   ```
-
-2. Create a virtual environment:
-   ```bash
-   python3 -m venv .venv
-   source .venv/bin/activate  # On Windows: .\.venv\Scripts\activate
-   ```
-
-3. Install dependencies:
-   ```bash
-   pip install -e ".[dev]"
-   ```
-
-## Usage
-
-Run the hello world application:
-
-```bash
-python -m hello_world.main
-```
-
-Or import and use in your code:
-
-```python
-from hello_world import greet
-
-print(greet("Python"))  # Output: Hello, Python!
 ```
 
 ## Development
@@ -182,30 +124,57 @@ print(greet("Python"))  # Output: Hello, Python!
 ### Running Tests
 
 ```bash
-pytest tests/ -v
+# Run all tests
+pytest
+
+# Run tests in verbose mode
+pytest -v
+
+# Run a specific test file
+pytest tests/test_main.py -v
 ```
 
-### Running Tests with Coverage
+### Coverage
+
+This project enforces **100% code coverage**. Pull requests that drop below
+100% are rejected automatically by GitHub Actions. Verify locally before
+committing:
 
 ```bash
-# Generate HTML coverage report
-pytest tests/ -v --cov=src/hello_world --cov-report=html
-
-# Generate XML coverage report (used by CodeCov in CI)
+# Same invocation as CI / CodeCov — fails under 100%
 pytest --cov --cov-branch --cov-report=xml --cov-fail-under=100
+
+# Generate a browsable HTML coverage report
+pytest --cov=src/hello_world --cov-report=html
 ```
 
-### Installing in Development Mode
+### Code Quality
+
+Two GitHub Actions workflows guard quality, mirrored locally by pre-commit:
+
+- **`tests.yml`** — runs pytest with coverage across Python 3.11–3.13.
+- **`ci.yml`** — enforces formatting, linting, and type checking with
+  auto-fixing and validation.
+
+Pre-commit runs the same formatting and linting (Ruff) and type
+checking (mypy) on every `git commit`. If a check fails, the commit is blocked
+until the issue is fixed; formatters auto-fix many issues for you.
 
 ```bash
-pip install -e .
+pre-commit install        # one-time setup
+pre-commit run --all-files
 ```
 
 ## Contributing
 
-1. Fork the repository
-2. Create a feature branch (`git checkout -b feature/amazing-feature`)
-3. Run tests with coverage before committing (see coverage requirements above)
-4. Commit your changes (`git commit -m 'Add some amazing feature'`)
-5. Push to the branch (`git push origin feature/amazing-feature`)
-6. Open a Pull Request
+1. Fork the repository.
+2. Create a feature branch (`git checkout -b feature/amazing-feature`).
+3. Run tests with coverage before committing (see [Coverage](#coverage)).
+4. Commit your changes (`git commit -m 'Add some amazing feature'`).
+5. Push to the branch (`git push origin feature/amazing-feature`).
+6. Open a Pull Request.
+
+---
+
+> Part of a [larger ecosystem of ~40 repos](https://docs.jacobpevans.com) —
+> see how it all fits together.


### PR DESCRIPTION
## Summary

Normalizes the README to the ecosystem **standalone-README** standard: it now describes only this repo, with the cross-repo story deferred to docs.jacobpevans.com.

- Normalize the getting-started heading to `## Installation`; `## Usage` retained.
- Fix the malformed `## 100% Code Coverage Required**` heading; coverage guidance folded into a single `Development > Coverage` subsection.
- Remove the duplicate "Quick Setup (Alternative)" block (redundant with Installation) and de-emoji headings.
- Add the canonical hub footer once at the very end.

This repo is a **project template**, so template-usage content is retained — only OTHER ecosystem-repo references were in scope. None existed: the README had no sibling-repo links or prose, and the only external links are this repo's own CI/CodeCov badges (kept).

## Linear

JAC-141

## Test plan

- `markdownlint-cli2 README.md` → 0 errors.
- Grep for sibling repo names (`nix-*`, `ansible-*`, `terraform-*`, `cc-edge`, `ai-*`, `dryvist`) → none but self-referential badges.
- Headings verified: `## Installation` and `## Usage` both present; malformed heading removed.
- Only `README.md` changed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013o7MG3YsoYKh59PT6aQvrb