### PR TITLE
ci(zizmor): re-enable the zizmor gate (closes #82)

### DIFF
--- a/.github/workflows/ci-gate.yml
+++ b/.github/workflows/ci-gate.yml
@@ -34,9 +34,6 @@ jobs:
     with:
       markdown_lint: true
       file_size: true
-      # Staged: pre-existing workflow-security findings tracked in #82;
-      # enable once resolved.
-      zizmor: false
       filters: |
         markdown:
           - '**.md'


### PR DESCRIPTION
## Summary

Re-enables the zizmor security gate by removing the staged `zizmor: false`.

All of #82's pre-existing findings were un-actionable-here (95 `ref-version-mismatch` on gh-aw generated `*.lock.yml` + 1 first-party `_gh-aw-pin-refresh.yml@main` ref). Both are now handled centrally in `dryvist/.github` (dryvist/.github#90): `ref-version-mismatch` ignored on gh-aw lock files, `JacobPEvans*` allowlisted. A fresh scan reports **zero findings**.

Closes #82

🤖 Generated with [Claude Code](https://claude.com/claude-code)